### PR TITLE
Fix for body failed validation: body.parent should be defined, instead was undefined.

### DIFF
--- a/src/Notion/Objects/Database.php
+++ b/src/Notion/Objects/Database.php
@@ -13,7 +13,7 @@ class Database extends ObjectBase
 
     protected function handleResponse($data): void
     {
-        $this->setProperties($data);
+        $this->properties = $this->setProperties($data);
 
         $title = new RichText($data->title);
 


### PR DESCRIPTION
Fixes empty array being passed to the 'Notion\Objects\Page->initProperties' method, causing error from Notion API:
body failed validation: body.parent should be defined, instead was undefined.