### PR TITLE
fix: allow Guzzle 6.x version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "guzzlehttp/guzzle": "^7.0.1",
+        "guzzlehttp/guzzle": "^6.3 || ^7.0.1",
         "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
Your code is compatible with Guzzle 6, so I think you should allow it.