### PR TITLE
fix: remove ray() usage & parent attribute

### DIFF
--- a/src/Notion/Objects/Page.php
+++ b/src/Notion/Objects/Page.php
@@ -43,9 +43,12 @@ class Page extends ObjectBase
     public function prepareForRequest()
     {
         $data = [
-            'parent' => $this->parent,
             'properties' => [],
         ];
+
+        if (null !== $this->parent) {
+            $data['parent'] = $this->parent;
+        }
 
         foreach ($this->properties as $property) {
             $value = $property->get();
@@ -64,8 +67,6 @@ class Page extends ObjectBase
                 $data['children'][] = $child->get();
             }
         }
-
-        ray($data);
 
         return $data;
     }


### PR DESCRIPTION
* The `ray()` function cannot works without the `require-dev` dependencies.
* The `parent` property cannot be `NULL`.