### PR TITLE
fix: init "select" property on set when not isset

### DIFF
--- a/src/Notion/Properties/Select.php
+++ b/src/Notion/Properties/Select.php
@@ -11,6 +11,10 @@ class Select extends PropertyBase
 
     public function set($value): void
     {
+        if (!isset($this->config->select)) {
+            $this->config->select = new \stdClass();
+        }
+
         $this->config->select->name = $value;
         unset($this->config->select->id, $this->config->select->color);
     }

--- a/src/Notion/Properties/Select.php
+++ b/src/Notion/Properties/Select.php
@@ -12,7 +12,7 @@ class Select extends PropertyBase
     public function set($value): void
     {
         if (!isset($this->config->select)) {
-            $this->config->select = new \stdClass();
+            $this->config->select = (object) [];
         }
 
         $this->config->select->name = $value;


### PR DESCRIPTION
When the select configuration on the Notion page is empty and if we are trying to set a value with your API, we got a warning message:

> PHP Warning:  Creating default object from empty value in Notion/Properties/Select.php on line 14

Adding a `isset()` condition and setting the `select` property fix this issue.
Please note that this issue may appear on other child classes of `PropertyBase`.