### PR TITLE
Allow installation of illuminate/support 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "guzzlehttp/guzzle": "^7.0.1",
-        "illuminate/support": "^6.0|^7.0|^8.0"
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.17",


### PR DESCRIPTION
### Changed
- With Laravel 9.x releasing in a couple of days, we should allow installing this library in the latest version of the framework