### PR TITLE
Properties array key generation method change

### DIFF
--- a/src/Notion/ObjectBase.php
+++ b/src/Notion/ObjectBase.php
@@ -41,7 +41,7 @@ class ObjectBase
     {
         $this->notion = $notion;
 
-        if (! $data) {
+        if (!$data) {
             return;
         }
 
@@ -55,8 +55,8 @@ class ObjectBase
 
     protected function setProperties($data): void
     {
-        $this->id               = $data->id;
-        $this->created_time     = $data->created_time;
+        $this->id = $data->id;
+        $this->created_time = $data->created_time;
         $this->last_edited_time = $data->last_edited_time;
 
         if (isset($data->archived)) {
@@ -65,7 +65,8 @@ class ObjectBase
 
         if (property_exists($data, 'properties')) {
             foreach ($data->properties as $label => $property) {
-                $this->properties[Str::camel($label)] = $this->createNewProperty($label, $property);
+                $this->properties[sha1($label)] = $this->createNewProperty($label, $property);
+                $this->propertiesCamelCaseAliases[Str::camel($label)] = sha1($label);
             }
         }
 

--- a/src/Notion/Objects/Page.php
+++ b/src/Notion/Objects/Page.php
@@ -1,5 +1,6 @@
 <?php namespace Notion\Objects;
 
+use Illuminate\Support\Str;
 use Notion\ObjectBase;
 use Notion\Http\Response;
 
@@ -8,6 +9,8 @@ class Page extends ObjectBase
     protected $endpoint = 'pages';
 
     protected $properties = [];
+
+    protected $propertiesCamelCaseAliases = [];
 
     protected $parent;
 
@@ -65,7 +68,7 @@ class Page extends ObjectBase
             }
         }
 
-        ray($data);
+        if (function_exists('ray')) ray($data);
 
         return $data;
     }
@@ -74,32 +77,51 @@ class Page extends ObjectBase
     {
         $this->properties = $data;
 
+        // generate aliases for camelCase properties
+        foreach ($data as $sha1key => $property) {
+            $this->propertiesCamelCaseAliases[Str::camel($property->name)] = sha1($property->name);
+        }
+
         return $this;
     }
 
     public function __get($property)
     {
-        if (!isset($this->properties[$property])) {
-            return $this->$property;
+        // search propery by sha1 key
+        if (isset($this->properties[sha1($property)])) {
+            return $this->properties[sha1($property)]->value();
         }
 
-        return $this->properties[$property]
-            ->value();
+        // fallback for camelCase alias
+        if(isset($this->propertiesCamelCaseAliases[$property]) && isset($this->properties[$this->propertiesCamelCaseAliases[$property]])) {
+            return $this->properties[$this->propertiesCamelCaseAliases[$property]]->value();
+        }
+
+        // other cases- return class propery
+        return $this->$property;
     }
 
     public function __set($property, $value)
     {
-        if (!isset($this->properties[$property])) {
-            $this->$property = $value;
+        // if we have this property in our sha1-keyed array
+        if (isset($this->properties[sha1($property)])) {
+            $this->properties[sha1($property)]->set($value);
             return;
         }
 
-        $this->properties[$property]->set($value);
+        // else check if it is camelCase alias
+        if(isset($this->propertiesCamelCaseAliases[$property]) && isset($this->properties[$this->propertiesCamelCaseAliases[$property]])) {
+            $this->properties[$this->propertiesCamelCaseAliases[$property]]->set($value);
+            return;
+        }
+
+        // set class property in other cases
+        $this->$property = $value;
     }
 
     public function __isset($property)
     {
-        return isset($this->properties[$property]);
+        return isset($this->properties[sha1($property)]) || (isset($this->propertiesCamelCaseAliases[$property]) && isset($this->properties[$this->propertiesCamelCaseAliases[$property]]));
     }
 
     public function save()


### PR DESCRIPTION
**Proposal:** 
Change key generation method from  `$this->properties[Str::camel($label)]` to this ` $this->properties[sha1($label)]`

**Reason:** 
- non-Latin titles are "camelcased" incorrectly
- some non-letter titles become empty strings (for example: `_`)
- thus, different titles have same keys in some cases (for example: `_` and `__`)

If we generate `sha1` from the title - we get the unique array key with a fairly high probability.
Now we can refer to properties with their Notion titles: `$page->Name`, `$page->Status`, etc.
Also, we can refer to properties with space in title `$page->{'Show On Website'}` and to non-latin properties: `$page->{'Дата просмотра'}`

**Code style and backward compatibility**
To follow code style for latin-letter-named properties case and for providing backward compatibility we store _camelcased_ titles as aliases to sha1-keys. So, the `$page->showOnWebsite` still works the same as `$page->{'Show On Website'}`

**Testing**
Although I checked this on my tables, it's better to be tested additionally ;)


**p.s.** Added `function_exists` check for the `ray` call